### PR TITLE
Fix Accessing `['yum-ius'] ['repos']` Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the yum-ius cookbook.
 
+## Unreleased
+
+- Fix accessing the `default['yum-ius']['repos']` attribute
+
 ## 3.2.7 - *2023-07-10*
 
 ## 3.2.6 - *2023-05-17*

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 Chef::Log.warn 'IUS no longer supports EL 5 packages as RHEL 5 has been EOLed.' if node['platform_version'].to_i == 5
 
-node['yum-ius']['repos'].each do |repo|
+node.default['yum-ius']['repos'].each do |repo|
   next unless node['yum'][repo]['managed']
   include_recipe 'yum-epel' unless run_context.loaded_recipe?('yum-epel')
   yum_repository repo do


### PR DESCRIPTION
# Description

Changes `node['yum-ius']['repos']` to `node.default['yum-ius']['repos']` in the `default` recipe so access to the attribute can happen correctly.

## Issues Resolved

Fixes ``undefined method `[]' for nil:NilClass`` error raised when trying to include the `default` recipe in another cookbook.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ not applicable ] New functionality includes testing.
- [ not applicable ] New functionality has been documented in the README if applicable.
